### PR TITLE
Provide a default nginx.conf with explicit number of worker_processes

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -1,0 +1,139 @@
+types {
+
+  # Data interchange
+
+    application/atom+xml                  atom;
+    application/json                      json map topojson;
+    application/ld+json                   jsonld;
+    application/rss+xml                   rss;
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc7946#section-12
+    application/geo+json                  geojson;
+    application/xml                       xml;
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc3870#section-2
+    application/rdf+xml                   rdf;
+
+
+  # JavaScript
+
+    # Servers should use text/javascript for JavaScript resources.
+    # https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages
+    text/javascript                       js mjs;
+    application/wasm                      wasm;
+
+
+  # Manifest files
+
+    application/manifest+json             webmanifest;
+    application/x-web-app-manifest+json   webapp;
+    text/cache-manifest                   appcache;
+
+
+  # Media files
+
+    audio/midi                            mid midi kar;
+    audio/mp4                             aac f4a f4b m4a;
+    audio/mpeg                            mp3;
+    audio/ogg                             oga ogg opus;
+    audio/x-realaudio                     ra;
+    audio/x-wav                           wav;
+    audio/x-matroska                      mka;
+    image/bmp                             bmp;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/webp                            webp;
+    image/x-jng                           jng;
+    video/3gpp                            3gp 3gpp;
+    video/mp4                             f4p f4v m4v mp4;
+    video/mpeg                            mpeg mpg;
+    video/ogg                             ogv;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asf asx;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+    video/x-matroska                      mkv mk3d;
+
+    # Serving `.ico` image files with a different media type
+    # prevents Internet Explorer from displaying then as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+
+    image/x-icon                          cur ico;
+
+
+  # Microsoft Office
+
+    application/msword                                                         doc;
+    application/vnd.ms-excel                                                   xls;
+    application/vnd.ms-powerpoint                                              ppt;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+
+  # Web fonts
+
+    font/woff                             woff;
+    font/woff2                            woff2;
+    application/vnd.ms-fontobject         eot;
+    font/ttf                              ttf;
+    font/collection                       ttc;
+    font/otf                              otf;
+
+
+  # Other
+
+    application/java-archive              ear jar war;
+    application/mac-binhex40              hqx;
+    application/octet-stream              bin deb dll dmg exe img iso msi msm msp safariextz;
+    application/pdf                       pdf;
+    application/postscript                ai eps ps;
+    application/rtf                       rtf;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/vnd.wap.wmlc              wmlc;
+    application/x-7z-compressed           7z;
+    application/x-bb-appworld             bbaw;
+    application/x-bittorrent              torrent;
+    application/x-chrome-extension        crx;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-opera-extension         oex;
+    application/x-perl                    pl pm;
+    application/x-pilot                   pdb prc;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            crt der pem;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xslt+xml                  xsl;
+    application/zip                       zip;
+    text/calendar                         ics;
+    text/css                              css;
+    text/csv                              csv;
+    text/html                             htm html shtml;
+    text/markdown                         md markdown;
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vcard                            vcard vcf;
+    text/vnd.rim.location.xloc            xloc;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/vtt                              vtt;
+    text/x-component                      htc;
+
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -92,5 +92,5 @@ http {
   # placed in the sites-available folder, and then the configuration should be enabled
   # by creating a symlink to it in the sites-enabled folder.
   # See doc/sites-enabled.md for more info.
-  include conf.d/*.conf;
+  include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,91 +1,97 @@
-# /etc/nginx/nginx.conf
-
-user nginx;
-
-# Pin number of worker processes to 1
+# Configuration File - Nginx Server Configs
+# https://nginx.org/en/docs/
+# Run as a unique, less privileged user for security reasons.
+# Default: nobody nobody
+# https://nginx.org/en/docs/ngx_core_module.html#user
+user www-data;
+# Sets the worker threads to the number of CPU cores available in the system for best performance.
+# Should be > the number of CPU cores.
+# Maximum number of connections = worker_processes * worker_connections
+# Default: 1
+# https://nginx.org/en/docs/ngx_core_module.html#worker_processes
 worker_processes 1;
-
-# Enables the use of JIT for regular expressions to speed-up their processing.
-pcre_jit on;
-
-# Configures default error logger.
-error_log /var/log/nginx/error.log warn;
-
-# Includes files with directives to load dynamic modules.
-include /etc/nginx/modules/*.conf;
-
-
+# Maximum number of open files per worker process.
+# Should be > worker_connections.
+# Default: no limit
+# https://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
+worker_rlimit_nofile 8192;
+# Provides the configuration file context in which the directives
+# that affect connection processing are specified.
+# https://nginx.org/en/docs/ngx_core_module.html#events
 events {
-	# The maximum number of simultaneous connections that can be opened by
-	# a worker process.
-	worker_connections 1024;
+  # If you need more connections than this, you start optimizing your OS.
+  # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
+  # Should be < worker_rlimit_nofile.
+  # Default: 512
+  # https://nginx.org/en/docs/ngx_core_module.html#worker_connections
+  worker_connections 8000;
 }
-
+# Log errors and warnings to this file
+# This is only used when you don't override it on a server{} level
+# Default: logs/error.log error
+# https://nginx.org/en/docs/ngx_core_module.html#error_log
+error_log  /var/log/nginx/error.log warn;
+# The file storing the process ID of the main process
+# Default: logs/nginx.pid
+# https://nginx.org/en/docs/ngx_core_module.html#pid
+pid /var/run/nginx.pid;
 http {
-	# Includes mapping of file name extensions to MIME types of responses
-	# and defines the default type.
-	include /etc/nginx/mime.types;
-	default_type application/octet-stream;
-
-	# Name servers used to resolve names of upstream servers into addresses.
-	# It's also needed when using tcpsocket and udpsocket in Lua modules.
-	#resolver 208.67.222.222 208.67.220.220;
-
-	# Don't tell nginx version to clients.
-	server_tokens off;
-
-	# Specifies the maximum accepted body size of a client request, as
-	# indicated by the request header Content-Length. If the stated content
-	# length is greater than this size, then the client receives the HTTP
-	# error code 413. Set to 0 to disable.
-	client_max_body_size 1m;
-
-	# Timeout for keep-alive connections. Server will close connections after
-	# this time.
-	keepalive_timeout 65;
-
-	# Sendfile copies data between one FD and other from within the kernel,
-	# which is more efficient than read() + write().
-	sendfile on;
-
-	# Don't buffer data-sends (disable Nagle algorithm).
-	# Good for sending frequent small bursts of data in real time.
-	tcp_nodelay on;
-
-	# Causes nginx to attempt to send its HTTP response head in one packet,
-	# instead of using partial frames.
-	#tcp_nopush on;
-
-
-	# Path of the file with Diffie-Hellman parameters for EDH ciphers.
-	#ssl_dhparam /etc/ssl/nginx/dh2048.pem;
-
-	# Specifies that our cipher suits should be preferred over client ciphers.
-	ssl_prefer_server_ciphers on;
-
-	# Enables a shared SSL cache with size that can hold around 8000 sessions.
-	ssl_session_cache shared:SSL:2m;
-
-
-	# Enable gzipping of responses.
-	#gzip on;
-
-	# Set the Vary HTTP header as defined in the RFC 2616.
-	gzip_vary on;
-
-	# Enable checking the existence of precompressed files.
-	#gzip_static on;
-
-
-	# Specifies the main log format.
-	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-			'$status $body_bytes_sent "$http_referer" '
-			'"$http_user_agent" "$http_x_forwarded_for"';
-
-	# Sets the path, format, and configuration for a buffered log write.
-	access_log /var/log/nginx/access.log main;
-
-
-	# Includes virtual hosts configs.
-	include /etc/nginx/conf.d/*.conf;
+  # Hide nginx version information
+  server_tokens off;
+  # Specify MIME types for files.
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#types
+  include mime.types;
+  # Default: text/plain
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#default_type
+  default_type application/octet-stream;
+  # Specify a charset
+  # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
+  charset utf-8;
+  # Update charset_types to match updated mime.types.
+  # text/html is always included by charset module.
+  # Default: text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml
+  # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset_types
+  charset_types
+    text/css
+    text/plain
+    text/vnd.wap.wml
+    text/javascript
+    application/json
+    application/rss+xml
+    application/xml;
+  # Include $http_x_forwarded_for within default format used in log files
+  # https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  # Log access to this file
+  # This is only used when you don't override it on a server{} level
+  # Default: logs/access.log combined
+  # https://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+  access_log  /var/log/nginx/access.log main;
+  # How long to allow each connection to stay idle.
+  # Longer values are better for each individual client, particularly for SSL,
+  # but means that worker connections are tied up longer.
+  # Default: 75s
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
+  keepalive_timeout 75s;
+  # Speed up file transfers by using sendfile() to copy directly
+  # between descriptors rather than using read()/write().
+  # For performance reasons, on FreeBSD systems w/ ZFS
+  # this option should be disabled as ZFS's ARC caches
+  # frequently used files in RAM by default.
+  # Default: off
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#sendfile
+  sendfile on;
+  # Don't send out partial frames; this increases throughput
+  # since TCP frames are filled up before being sent out.
+  # Default: off
+  # https://nginx.org/en/docs/http/ngx_http_core_module.html#tcp_nopush
+  tcp_nopush on;
+  # Include files in the sites-enabled folder. server{} configuration files should be
+  # placed in the sites-available folder, and then the configuration should be enabled
+  # by creating a symlink to it in the sites-enabled folder.
+  # See doc/sites-enabled.md for more info.
+  include conf.d/*.conf;
+  include sites-enabled/*;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,91 @@
+# /etc/nginx/nginx.conf
+
+user nginx;
+
+# Pin number of worker processes to 1
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Configures default error logger.
+error_log /var/log/nginx/error.log warn;
+
+# Includes files with directives to load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+
+events {
+	# The maximum number of simultaneous connections that can be opened by
+	# a worker process.
+	worker_connections 1024;
+}
+
+http {
+	# Includes mapping of file name extensions to MIME types of responses
+	# and defines the default type.
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	# Name servers used to resolve names of upstream servers into addresses.
+	# It's also needed when using tcpsocket and udpsocket in Lua modules.
+	#resolver 208.67.222.222 208.67.220.220;
+
+	# Don't tell nginx version to clients.
+	server_tokens off;
+
+	# Specifies the maximum accepted body size of a client request, as
+	# indicated by the request header Content-Length. If the stated content
+	# length is greater than this size, then the client receives the HTTP
+	# error code 413. Set to 0 to disable.
+	client_max_body_size 1m;
+
+	# Timeout for keep-alive connections. Server will close connections after
+	# this time.
+	keepalive_timeout 65;
+
+	# Sendfile copies data between one FD and other from within the kernel,
+	# which is more efficient than read() + write().
+	sendfile on;
+
+	# Don't buffer data-sends (disable Nagle algorithm).
+	# Good for sending frequent small bursts of data in real time.
+	tcp_nodelay on;
+
+	# Causes nginx to attempt to send its HTTP response head in one packet,
+	# instead of using partial frames.
+	#tcp_nopush on;
+
+
+	# Path of the file with Diffie-Hellman parameters for EDH ciphers.
+	#ssl_dhparam /etc/ssl/nginx/dh2048.pem;
+
+	# Specifies that our cipher suits should be preferred over client ciphers.
+	ssl_prefer_server_ciphers on;
+
+	# Enables a shared SSL cache with size that can hold around 8000 sessions.
+	ssl_session_cache shared:SSL:2m;
+
+
+	# Enable gzipping of responses.
+	#gzip on;
+
+	# Set the Vary HTTP header as defined in the RFC 2616.
+	gzip_vary on;
+
+	# Enable checking the existence of precompressed files.
+	#gzip_static on;
+
+
+	# Specifies the main log format.
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+			'$status $body_bytes_sent "$http_referer" '
+			'"$http_user_agent" "$http_x_forwarded_for"';
+
+	# Sets the path, format, and configuration for a buffered log write.
+	access_log /var/log/nginx/access.log main;
+
+
+	# Includes virtual hosts configs.
+	include /etc/nginx/conf.d/*.conf;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,7 @@
 # Run as a unique, less privileged user for security reasons.
 # Default: nobody nobody
 # https://nginx.org/en/docs/ngx_core_module.html#user
-user www-data;
+user nginx;
 # Sets the worker threads to the number of CPU cores available in the system for best performance.
 # Should be > the number of CPU cores.
 # Maximum number of connections = worker_processes * worker_connections
@@ -40,7 +40,7 @@ http {
   server_tokens off;
   # Specify MIME types for files.
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#types
-  include mime.types;
+  include /etc/nginx/mime.types;
   # Default: text/plain
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#default_type
   default_type application/octet-stream;
@@ -93,5 +93,4 @@ http {
   # by creating a symlink to it in the sites-enabled folder.
   # See doc/sites-enabled.md for more info.
   include conf.d/*.conf;
-  include sites-enabled/*;
 }

--- a/runtime.dockerfile
+++ b/runtime.dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.16-alpine
 
 ADD nginx.conf /etc/nginx/nginx.conf
+ADD mime.types /etc/nginx/mime.types
 RUN nginx -t
 
 ONBUILD COPY --from=0 /usr/src/app/_site/ /usr/share/nginx/html/

--- a/runtime.dockerfile
+++ b/runtime.dockerfile
@@ -1,5 +1,8 @@
 FROM nginx:1.16-alpine
 
+ADD nginx.conf /etc/nginx/nginx.conf
+RUN nginx -t
+
 ONBUILD COPY --from=0 /usr/src/app/_site/ /usr/share/nginx/html/
 ONBUILD ADD nginx.conf /etc/nginx/conf.d/default.conf
 # Make sure our config is fine after adding it into the container


### PR DESCRIPTION
The provided default nginx config from the alpine nginx image sets `worker_processes` to `auto` which in docker will result in us reading the host cpu count and using that many workers. This is sub-optimal for us in most cases so we'll stick to 1 worker process for now. Config is copied from latest alpine image apart from the `worker_processes` change.